### PR TITLE
Storageに置かれたCSVをBigQueryにLoadする機能を追加

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -37,6 +37,7 @@ func init() {
 	setupScheduleAPI(swPlugin)
 	setupScheduleDatastoreExportAPI(swPlugin)
 	setupScheduleCloudSQLExportAPI(swPlugin)
+	setupStorageBQLoadConfigAPI(swPlugin)
 	setUpTQBuildeQueryAPI(swPlugin)
 	setupTQDatastoreExportAPI(swPlugin)
 	setupTQCloudSQLExportAPI(swPlugin)

--- a/backend/main.go
+++ b/backend/main.go
@@ -49,6 +49,7 @@ func init() {
 	ucon.HandleFunc(http.MethodPost, "/ocn/datastore-export", ReceiveOCNHandler)
 	ucon.HandleFunc(http.MethodPost, "/tq/gcs/object-to-bq", ImportBigQueryHandleFunc("datastore_imports"))
 	ucon.HandleFunc(http.MethodPost, "/ocn/cloudsql-export", ReceiveCloudSQLExportOCNHandler)
+	ucon.HandleFunc(http.MethodPost, "/ocn/storage-bqload", ReceiveStorageBQLoadOCNHandler)
 
 	ucon.DefaultMux.Prepare()
 	http.Handle("/", ucon.DefaultMux)

--- a/backend/storage_bqload_config_api.go
+++ b/backend/storage_bqload_config_api.go
@@ -1,0 +1,57 @@
+package backend
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/favclip/ucon"
+	"github.com/favclip/ucon/swagger"
+)
+
+// StorageBQLoadConfigAPI is Cloud StorageにUploadされたファイルをBigQueryにLoadするConfigに関するAPI
+type StorageBQLoadConfigAPI struct{}
+
+func setupStorageBQLoadConfigAPI(swPlugin *swagger.Plugin) {
+	api := &StorageBQLoadConfigAPI{}
+
+	tag := swPlugin.AddTag(&swagger.Tag{Name: "StorageBQLoadConfig", Description: "StorageBQLoadConfig list"})
+	var hInfo *swagger.HandlerInfo
+
+	hInfo = swagger.NewHandlerInfo(api.Post)
+	ucon.Handle(http.MethodPost, "/storageBQLoadConfig", hInfo)
+	hInfo.Description, hInfo.Tags = "post to StorageBQLoadConfig", []string{tag.Name}
+}
+
+// StorageBQLoadConfigAPIPostRequest is StorageBQLoadConfigAPI Post form
+type StorageBQLoadConfigAPIPostRequest struct {
+	FrmStorageBucket     string `json:"frmStorageBucket"`
+	DstBigQueryProjectID string `json:"dstBigQueryProjectID"`
+	DstBigQueryDataset   string `json:"dstBigQueryDataset"`
+}
+
+// StorageBQLoadConfigAPIPostResponse is StorageBQLoadConfigAPI Post response
+type StorageBQLoadConfigAPIPostResponse struct {
+	*StorageBQLoadConfig
+}
+
+// Post is Payloadの情報を元に StorageBQLoadConfig を新規でDatastoreに登録するAPI Handler
+func (api *StorageBQLoadConfigAPI) Post(ctx context.Context, form *StorageBQLoadConfigAPIPostRequest) (*StorageBQLoadConfigAPIPostResponse, error) {
+	store := StorageBQLoadConfigStore{}
+
+	ds, err := fromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &StorageBQLoadConfig{
+		FrmStorageBucket:     form.FrmStorageBucket,
+		DstBigQueryProjectID: form.DstBigQueryProjectID,
+		DstBigQueryDataset:   form.DstBigQueryDataset,
+	}
+	key := store.NewKey(ctx, ds)
+	sc, err := store.Put(ctx, key, config)
+	if err != nil {
+		return nil, err
+	}
+	return &StorageBQLoadConfigAPIPostResponse{sc}, nil
+}

--- a/backend/storage_bqload_config_api.go
+++ b/backend/storage_bqload_config_api.go
@@ -48,7 +48,7 @@ func (api *StorageBQLoadConfigAPI) Post(ctx context.Context, form *StorageBQLoad
 		DstBigQueryProjectID: form.DstBigQueryProjectID,
 		DstBigQueryDataset:   form.DstBigQueryDataset,
 	}
-	key := store.NewKey(ctx, ds)
+	key := store.Key(ctx, ds, form.FrmStorageBucket)
 	sc, err := store.Put(ctx, key, config)
 	if err != nil {
 		return nil, err

--- a/backend/storage_bqload_config_api_test.go
+++ b/backend/storage_bqload_config_api_test.go
@@ -1,0 +1,45 @@
+package backend
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/favclip/testerator"
+)
+
+// とりあえず200 OKが返ってくることを確認
+func TestStorageBQLoadConfigAPI_Post(t *testing.T) {
+	inst, _, err := testerator.SpinUp()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer testerator.SpinDown()
+
+	form := StorageBQLoadConfigAPIPostRequest{
+		FrmStorageBucket:     "hogebucket",
+		DstBigQueryProjectID: "hogeproject",
+		DstBigQueryDataset:   "hogedataset",
+	}
+	b, err := json.Marshal(form)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := inst.NewRequest(http.MethodPost, "/storageBQLoadConfig", bytes.NewBuffer(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Header.Set("Content-Type", "application/json;charset=utf-8")
+
+	w := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		b, _ := ioutil.ReadAll(w.Body)
+		t.Fatalf("unexpected %d, expected 200, body=%s", w.Code, string(b))
+	}
+}

--- a/backend/storage_bqload_config_store.go
+++ b/backend/storage_bqload_config_store.go
@@ -1,0 +1,74 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"go.mercari.io/datastore"
+)
+
+// StorageBQLoadConfig is Cloud Storage上に置かれたFileをBigQueryにLoadするための設定
+// File名と同じTable名 かつ スキーマはAutoDetectで設定するのを前提にしているので、設定項目は最小限
+type StorageBQLoadConfig struct {
+	Key                  datastore.Key `json:"-" datastore:"-"`
+	FrmStorageBucket     string        `json:"frmStorageBucket"`     // LoadするFileがあるCloud Storage Bucket
+	DstBigQueryProjectID string        `json:"dstBigQueryProjectID"` // Load先のBigQueryのProjectID
+	DstBigQueryDataset   string        `json:"dstBigQueryDataset"`   // Load先のBigQueryのDataset
+	CreatedAt            time.Time     `json:"createdAt"`
+	UpdatedAt            time.Time     `json:"updatedAt"`
+	SchemaVersion        int           `json:"-"`
+}
+
+var _ datastore.PropertyLoadSaver = &StorageBQLoadConfig{}
+
+// Load is Load
+func (model *StorageBQLoadConfig) Load(ctx context.Context, ps []datastore.Property) error {
+	return datastore.LoadStruct(ctx, model, ps)
+}
+
+// Save is Save
+func (model *StorageBQLoadConfig) Save(ctx context.Context) ([]datastore.Property, error) {
+	model.SchemaVersion = 1
+	if model.CreatedAt.IsZero() {
+		model.CreatedAt = time.Now()
+	}
+	model.UpdatedAt = time.Now()
+	return datastore.SaveStruct(ctx, model)
+}
+
+// StorageBQLoadConfigStore is StorageBQLoadConfig Functions
+type StorageBQLoadConfigStore struct{}
+
+// Kind is Get StorageBQLoadConfigStore Kind Name
+func (store *StorageBQLoadConfigStore) Kind() string {
+	return "StorageBQLoadConfig"
+}
+
+// NewKey is Create StorageBQLoadConfig Key
+// KeyNameとしてUUIDを利用
+func (store *StorageBQLoadConfigStore) NewKey(ctx context.Context, client datastore.Client) datastore.Key {
+	return client.NameKey(store.Kind(), uuid.New().String(), nil)
+}
+
+// Key is Create StorageBQLoadConfig Key
+func (store *StorageBQLoadConfigStore) Key(ctx context.Context, client datastore.Client, id string) datastore.Key {
+	return client.NameKey(store.Kind(), id, nil)
+}
+
+// Put is StorageBQLoadConfig をDatastoreにPutする
+func (store *StorageBQLoadConfigStore) Put(ctx context.Context, key datastore.Key, config *StorageBQLoadConfig) (*StorageBQLoadConfig, error) {
+	ds, err := fromContext(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "fromContext")
+	}
+	_, err = ds.Put(ctx, key, config)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("datastore.Put: key = %v", key))
+	}
+	config.Key = key
+
+	return config, nil
+}

--- a/backend/storage_bqload_config_store_test.go
+++ b/backend/storage_bqload_config_store_test.go
@@ -1,0 +1,54 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/favclip/testerator"
+)
+
+func TestStorageBQLoadConfigStore_Put(t *testing.T) {
+	_, ctx, err := testerator.SpinUp() // gae/pythonのインスタンスが無ければ起動、あれば使いまわす
+	if err != nil {
+		t.Fatalf("%+v\n", err)
+	}
+	defer testerator.SpinDown() // プロセスをシャットダウンせずに、Datastoreなどの内容をクリアする
+	ds, err := fromContext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := StorageBQLoadConfigStore{}
+
+	entity := &StorageBQLoadConfig{
+		FrmStorageBucket:     "hoge",
+		DstBigQueryProjectID: "hogeprojectid",
+		DstBigQueryDataset:   "hogedataset",
+	}
+
+	key := store.NewKey(ctx, ds)
+	stored, err := store.Put(ctx, key, entity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Key == nil {
+		t.Fatal("expected Key is not nil")
+	}
+	if e, g := entity.FrmStorageBucket, stored.FrmStorageBucket; e != g {
+		t.Fatalf("expected FrmStorageBucket is %s; got %s", e, g)
+	}
+	if e, g := entity.DstBigQueryProjectID, stored.DstBigQueryProjectID; e != g {
+		t.Fatalf("expected DstBigQueryProjectID is %s; got %s", e, g)
+	}
+	if e, g := entity.DstBigQueryDataset, stored.DstBigQueryDataset; e != g {
+		t.Fatalf("expected DstBigQueryDataset is %s; got %s", e, g)
+	}
+	if stored.CreatedAt.IsZero() {
+		t.Fatal("expected CreatedAt is Not Zero")
+	}
+	if stored.UpdatedAt.IsZero() {
+		t.Fatal("expected UpdatedAt is Not Zero")
+	}
+	if e, g := 1, stored.SchemaVersion; e != g {
+		t.Fatalf("expected SchemaVersion is %d; got %d", e, g)
+	}
+}

--- a/backend/storage_bqload_config_store_test.go
+++ b/backend/storage_bqload_config_store_test.go
@@ -25,8 +25,59 @@ func TestStorageBQLoadConfigStore_Put(t *testing.T) {
 		DstBigQueryDataset:   "hogedataset",
 	}
 
-	key := store.NewKey(ctx, ds)
+	key := store.Key(ctx, ds, entity.FrmStorageBucket)
 	stored, err := store.Put(ctx, key, entity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Key == nil {
+		t.Fatal("expected Key is not nil")
+	}
+	if e, g := entity.FrmStorageBucket, stored.FrmStorageBucket; e != g {
+		t.Fatalf("expected FrmStorageBucket is %s; got %s", e, g)
+	}
+	if e, g := entity.DstBigQueryProjectID, stored.DstBigQueryProjectID; e != g {
+		t.Fatalf("expected DstBigQueryProjectID is %s; got %s", e, g)
+	}
+	if e, g := entity.DstBigQueryDataset, stored.DstBigQueryDataset; e != g {
+		t.Fatalf("expected DstBigQueryDataset is %s; got %s", e, g)
+	}
+	if stored.CreatedAt.IsZero() {
+		t.Fatal("expected CreatedAt is Not Zero")
+	}
+	if stored.UpdatedAt.IsZero() {
+		t.Fatal("expected UpdatedAt is Not Zero")
+	}
+	if e, g := 1, stored.SchemaVersion; e != g {
+		t.Fatalf("expected SchemaVersion is %d; got %d", e, g)
+	}
+}
+
+func TestStorageBQLoadConfigStore_Get(t *testing.T) {
+	_, ctx, err := testerator.SpinUp() // gae/pythonのインスタンスが無ければ起動、あれば使いまわす
+	if err != nil {
+		t.Fatalf("%+v\n", err)
+	}
+	defer testerator.SpinDown() // プロセスをシャットダウンせずに、Datastoreなどの内容をクリアする
+	ds, err := fromContext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := StorageBQLoadConfigStore{}
+
+	entity := &StorageBQLoadConfig{
+		FrmStorageBucket:     "hoge",
+		DstBigQueryProjectID: "hogeprojectid",
+		DstBigQueryDataset:   "hogedataset",
+	}
+
+	key := store.Key(ctx, ds, entity.FrmStorageBucket)
+	_, err = store.Put(ctx, key, entity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err := store.Get(ctx, key)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
予め示したCloud StorageのBucketにCSVがUploadされた時に、OCNを受け取りBigQueryにLoadする機能を作成した

Close #34 