### PR TITLE
Datastore ExportのKindsが多い場合、複数のJobに分割するようにした

### DIFF
--- a/backend/cron_datastore_export_api.go
+++ b/backend/cron_datastore_export_api.go
@@ -35,16 +35,37 @@ func (api *CronDatastoreExportAPI) Get(ctx context.Context) error {
 	tq := TQDatastoreExportAPI{}
 	for _, v := range l {
 		// TODO 実行すべきかのハンドリングを追加
-		err := tq.Call(ctx, &TQDatastoreExportAPIPostRequest{
-			ProjectID: v.ProjectID,
-			Bucket:    v.Bucket,
-			Kinds:     v.Kinds,
-		})
-		if err != nil {
-			log.Errorf(ctx, "failed %v, %+v", v.Key, err)
-			return err
+		kindBlocks := buildBlocks(v.Kinds, 30) // Kindの数の上限がいくつなのかは分からないが、成功した値を入れている
+		for _, kinds := range kindBlocks {
+			err := tq.Call(ctx, &TQDatastoreExportAPIPostRequest{
+				ProjectID: v.ProjectID,
+				Bucket:    v.Bucket,
+				Kinds:     kinds,
+			})
+			if err != nil {
+				log.Errorf(ctx, "failed %v, %+v", v.Key, err)
+				return err
+			}
 		}
 	}
 
 	return nil
+}
+
+func buildBlocks(array []string, blockSize int) [][]string {
+	var blockSet [][]string
+	c := len(array) / blockSize
+	if len(array)%blockSize > 0.0 {
+		c++
+	}
+	last := len(array) - 1
+	for i := 0; i < c; i++ {
+		start := (i) * blockSize
+		end := start + blockSize
+		if end > last {
+			end = last
+		}
+		blockSet = append(blockSet, array[start:end])
+	}
+	return blockSet
 }

--- a/backend/cron_datastore_export_api_test.go
+++ b/backend/cron_datastore_export_api_test.go
@@ -75,3 +75,27 @@ func TestCronDatastoreExportAPI_Get(t *testing.T) {
 		t.Fatalf("unexpected Tasks.Bucket expected %s; got %s", e, g)
 	}
 }
+
+func TestBuildBlocks(t *testing.T) {
+	cases := []struct {
+		name       string
+		array      []string
+		blocSize   int
+		wantLength int
+	}{
+		{"empty", []string{}, 1, 0},
+		{"1", []string{"Hoge"}, 1, 1},
+		{"2", []string{"Hoge", "Fuga"}, 1, 2},
+		{"many", []string{"Hoge", "Fuga", "Moge", "Popo", "Poge"}, 2, 3},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildBlocks(tt.array, tt.blocSize)
+			if len(got) != tt.wantLength {
+				t.Errorf("want %v but got %v, %v", tt.wantLength, len(got), got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
close #46